### PR TITLE
20200319 22:12 백준알고리즘/2512/예산

### DIFF
--- a/StudyExamples/src/baekjun/divideandconquer/NationalBudget2512.java
+++ b/StudyExamples/src/baekjun/divideandconquer/NationalBudget2512.java
@@ -1,0 +1,58 @@
+package baekjun.divideandconquer;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class NationalBudget2512 {
+	static int N, total;
+	static int max = 0, ans;
+	static int[] local;
+	
+	static void solve(int left, int right) {
+		if(left > right) return;
+		
+		int budget = (left + right)/2;
+		int sum = 0;
+		for(int i = 0; i<N; i++) {
+			if(local[i] <= budget) sum += local[i];
+			else sum += budget;
+		}
+		
+		if(sum > total)
+			solve(left, budget - 1);
+		else {
+			if(max < sum) {
+				ans = budget;
+				solve(budget + 1, right);
+			}else
+				solve(budget + 1, right);
+		}
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		N = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		total = Integer.parseInt(br.readLine());
+		local = new int[N];
+		int max = 0;
+		for(int i = 0; i<N; i++) {
+			local[i] = Integer.parseInt(st.nextToken());
+			max = Math.max(local[i], max);
+		}
+		if(max * N <= total) bw.write(max + "");
+		else {
+			solve(0, max);
+			bw.write(ans + "");
+		}
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}


### PR DESCRIPTION
1) Category: 이분탐색, 분할정복
2) 문제: https://www.acmicpc.net/problem/2512
3) 풀이내용:
- 재귀 시작점의 최소값을 입력받은 예산 중 최소값으로 설정해서 한 번 틀렸다.
- 왜냐하면 전체 국가 예산이 지지리도 낮을 수 있기 때문이다. 
- 그래서 0 ~ max로 잡고 다시 돌려서 맞음