### PR TITLE
20200324 20:41 백준알고리즘/2468/안전지대

### DIFF
--- a/StudyExamples/src/baekjun/dfs/SafeZone2468.java
+++ b/StudyExamples/src/baekjun/dfs/SafeZone2468.java
@@ -1,0 +1,69 @@
+package baekjun.dfs;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class SafeZone2468 {
+	static int N;
+	static int height;
+	static int[][] map;
+	static int[] dy = {-1, 0, 1, 0};
+	static int[] dx = {0, 1, 0, -1};
+	static boolean[][] visit;
+	static ArrayList<Integer> list;
+	static StringTokenizer st;
+	
+	static void dfs(int y, int x, int k) {
+		if(list.size() == k) list.add(1);
+		
+		visit[y][x] = true;
+		for(int dir = 0; dir<4; dir++) {
+			int ny = y + dy[dir];
+			int nx = x + dx[dir];
+			if(ny < 0 || nx < 0 || ny >= N || nx >= N || visit[ny][nx]) continue;
+			else if(map[ny][nx] > height)
+				dfs(ny, nx, k);
+		}
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		int maxHeight = 0;
+		for(int i = 0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j = 0; j<N; j++){
+				map[i][j] = Integer.parseInt(st.nextToken());
+				maxHeight = Math.max(maxHeight, map[i][j]);
+			}
+		}
+		
+		int ans = 1;
+		for(int h = 1; h<maxHeight; h++) {
+			int cnt = 0;
+			height = h;
+			visit = new boolean[N][N];
+			list = new ArrayList<>();
+			list.add(0);
+			for(int i = 0; i<N; i++) {
+				for(int j = 0; j<N; j++) {
+					if(!visit[i][j] && map[i][j] > height)
+						dfs(i, j, ++cnt);
+				}
+			}
+			ans = Math.max(ans, list.size() - 1);
+		}
+		bw.write(ans + "");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}


### PR DESCRIPTION
1) Category: DFS
2) 문제: https://www.acmicpc.net/problem/2468
3) 풀이내용:
- 처음 지도를 입력받을 때 최대 높이를 구하고, 1부터 최대높이-1 까지 루프를 돌며 안전지대의 개수를 구한다.
- 0인 경우와 최대높이인 경우는 어차피 안전지대가 1, 0 이기 때문에 별도로 세어주지 않았다.
- map의 값을 계속 바꿔가면서 풀이하는 것 보다는 boolean 배열로 방문한지 확인하는 것이 효율적일 것으로 판단.