### PR TITLE
20200401 22:25 백준알고리즘/5719/거의 최단 경로

### DIFF
--- a/StudyExamples/src/baekjun/bfs/AlmostShortest5719.java
+++ b/StudyExamples/src/baekjun/bfs/AlmostShortest5719.java
@@ -1,0 +1,116 @@
+package baekjun.bfs;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class AlmostShortest5719 {
+	//dijkstra로 최단 경로를 찾고 최단 경로인 경우를 지운다. 이후 다시 최단경로를 구한다.
+	static int start, end;
+	static final int INF = 987654321;
+	static int[] dist;
+	static boolean[] visit;
+	static ArrayList<Node> adj[], path[];
+	static StringTokenizer st;
+	
+	static void dijkstra() {
+		Arrays.fill(visit, false);
+		Arrays.fill(dist, INF);
+		PriorityQueue<Node> pq = new PriorityQueue<Node>();
+		pq.add(new Node(start, 0));
+		dist[start] = 0;
+		while(!pq.isEmpty()) {
+			Node now = pq.poll();
+			if(visit[now.idx]) continue;
+			visit[now.idx] = true;
+			for(Node next : adj[now.idx]) {
+				if(next.val == -1) continue;
+				if(dist[next.idx] > dist[now.idx] + next.val) {
+					dist[next.idx] = dist[now.idx] + next.val;
+					pq.add(new Node(next.idx, dist[next.idx]));
+					path[next.idx].clear();
+					path[next.idx].add(new Node(now.idx, dist[next.idx]));
+				}else if(dist[next.idx] == dist[now.idx] + next.val)
+					path[next.idx].add(new Node(now.idx, dist[next.idx]));
+			}
+		}
+	}
+	
+	static void bfs() {
+		Queue<Integer> q = new LinkedList<Integer>();
+		q.add(end);
+		while(!q.isEmpty()) {
+			int now = q.poll();
+			for(Node n1 : path[now]) {
+				int neighbor = n1.idx;
+				for(Node n2 : adj[neighbor]) {
+					if(n2.idx == now)
+						n2.val = -1;
+				}
+				q.add(neighbor);
+			}
+		}
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		String str = "";
+		while(!(str = br.readLine()).equals("0 0")) {
+			//N,M 입력 및 배열 초기화
+			st = new StringTokenizer(str);
+			int N = Integer.parseInt(st.nextToken());
+			int M = Integer.parseInt(st.nextToken());
+			dist = new int[N];
+			visit = new boolean[N];
+			adj = new ArrayList[N];
+			path = new ArrayList[N];
+			for(int i = 0; i<N; i++) {
+				adj[i] = new ArrayList<Node>();
+				path[i] = new ArrayList<Node>();
+			}
+			
+			//S, D, 도로 입력
+			st = new StringTokenizer(br.readLine());
+			start = Integer.parseInt(st.nextToken());
+			end = Integer.parseInt(st.nextToken());
+			for(int i = 0; i<M; i++) {
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				int c = Integer.parseInt(st.nextToken());
+				adj[a].add(new Node(b, c));
+			}
+			
+			dijkstra();
+			bfs();
+			dijkstra();
+			
+			bw.write((dist[end] == INF)? "-1\n" : dist[end] + "\n");
+		}
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+	
+	static class Node implements Comparable<Node>{
+		int idx;
+		int val;
+		public Node(int idx, int val) {
+			this.idx = idx;
+			this.val = val;
+		}
+		@Override
+		public int compareTo(Node n) {
+			return this.val - n.val;
+		}
+	}
+}


### PR DESCRIPTION
1) Category: BFS, Dijkstra
2) 문제: https://www.acmicpc.net/problem/5719
3) 풀이내용: 
- dijkstra를 통해서 최단 경로를 찾아내는것은 그리 어려운 문제가 아니다.
- 하지만 문제의 조건은 최단 경로를 지나는 길은 모두 없애버렸을 때의 새로운 최단 경로를 구하는 것이다.
- 이말인 즉슨 첫 dijkstra에서 구해지는 최단 경로를 저장해두고 이를 지워주는 과정이 들어가야 한다.
- 이에 따라, dijkstra가 진행되면서 새로운 최소거리가 나온다면 path[nextVertex]를 초기화해주고 Node를 추가해주고, 같은 거리가 반복되서 나온다면 해당 배열에 node를 추가해준다.
- 이렇게 만들어진 path경로를 BFS알고리즘을 통해 다시 역추적해서 해당 도로를 모두 부셔버린다.
(부서진 도로의 val값은 -1로 변경)
- 이 과정을 마치고 다시 dijkstra를 진행한다면 다음 최단경로를 알아낼 수 있다.