### PR TITLE
20200401 23:22 백준알고리즘/6087/레이저 통신

### DIFF
--- a/StudyExamples/src/baekjun/bfs/LaserCommunication6087.java
+++ b/StudyExamples/src/baekjun/bfs/LaserCommunication6087.java
@@ -1,0 +1,78 @@
+package baekjun.bfs;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class LaserCommunication6087 {
+	static int W, H;
+	static int[] dy = {-1, 0, 1, 0};
+	static int[] dx = {0, 1, 0, -1};
+	static int[][] cnt;
+	static boolean[][] visit;
+	static char[][] map;
+	static Point start = new Point(-1, -1);
+	static Point end = new Point(-1, -1);
+	
+	static void bfs() {
+		Queue<Point> q = new LinkedList<Point>();
+		q.add(start);
+		visit[start.y][start.x] = true;
+		while(!q.isEmpty()) {
+			Point now = q.poll();
+			for(int dir = 0; dir<4; dir++) {
+				int ny = now.y + dy[dir];
+				int nx = now.x + dx[dir];
+				while(ny >= 0 && ny < H && nx >= 0 && nx < W && map[ny][nx] != '*') {
+					if(!visit[ny][nx] || cnt[ny][nx] > cnt[now.y][now.x] + 1) {
+						cnt[ny][nx] = cnt[now.y][now.x] + 1;
+						visit[ny][nx] = true;
+						q.add(new Point(ny, nx));
+					}
+					ny += dy[dir];
+					nx += dx[dir];
+				}
+			}
+		}
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		W = Integer.parseInt(st.nextToken());
+		H = Integer.parseInt(st.nextToken());
+		cnt = new int[H][W];
+		visit = new boolean[H][W];
+		map = new char[H][W];
+		for(int i = 0; i<H; i++) {
+			String str = br.readLine();
+			for(int j = 0; j<W; j++) {
+				map[i][j] = str.charAt(j);
+				if(map[i][j] == 'C') {
+					if(start.y == -1) start = new Point(i, j);
+					else end = new Point(i, j);
+				}
+			}
+		}
+		bfs();
+		bw.write(cnt[end.y][end.x] - 1 + "");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+	
+	static class Point{
+		int y;
+		int x;
+		public Point(int y, int x) {
+			this.y = y;
+			this.x = x;
+		}
+	}
+}


### PR DESCRIPTION
1) Category: BFS
2) 문제: https://www.acmicpc.net/problem/6087
3) 풀이내용:
- 실로 간단해보이는 문제지만, 사실 간단하지 않다기보단 간단하다.(???)
- 레이저는 일직선으로 진행하며 방향을 루프를 돌며 지정해주다보니 분명 더 적은 거울이 필요함에도 불구하고 먼저 방문했다는 이유 하나만으로 값이 갱신되지 않을 수 있다.
- 이에 따라, 방문하지 않은 노드이거나, 시작점 + 1 값 보다 도착점의 값이 크다면 값을 갱신시켜주도록 한다.
- 이 때, bfs로 한 칸씩 순회하는 것이 아닌 레이저의 특성을 따라 벽을 만나지 않거나 끝에 도달하지 않을때까지 진행시켜준다.