### PR TITLE
20200406 10:10 백준알고리즘/9935/문자열 폭발

### DIFF
--- a/StudyExamples/src/baekjun/string/StringBoom9935.java
+++ b/StudyExamples/src/baekjun/string/StringBoom9935.java
@@ -1,0 +1,49 @@
+package baekjun.string;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.Stack;
+
+public class StringBoom9935 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		String str = br.readLine();
+		String bomb = br.readLine();
+		Stack<Character> stack = new Stack<Character>();
+		for(int i = str.length()-1; i>=0; i--) {
+			boolean isBomb = false;
+			char c = str.charAt(i);
+			stack.push(c);
+			if(c == bomb.charAt(0) && stack.size() >= bomb.length()) {
+				isBomb = true;
+				for(int j = 0; j<bomb.length(); j++) {
+					if(bomb.charAt(j) != stack.get(stack.size() - 1 - j)) {
+						isBomb = false;
+						break;
+					}
+				}
+				if(isBomb) {
+					for(int j = 0; j<bomb.length(); j++)
+						stack.pop();
+				}
+			}
+		}
+		StringBuffer sb = new StringBuffer("");
+		if(stack.isEmpty())
+			sb = new StringBuffer("FRULA");
+		else {
+			while(!stack.isEmpty())
+				sb.append(stack.pop());
+		}
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}


### PR DESCRIPTION
1) Category: 문자열 처리
2) 문제: https://www.acmicpc.net/problem/9935
3) 풀이내용:
- 처음에는 문제를 잘못 해석하고 풀어 틀렸다. 이유는 폭발 문자열에 포함된 문자가 있으면 터지는 줄알고 replaceAll을 사용해서 풀었는데 그것이 아니었음.
- 폭발 문자열과 일치하는 문자열이 등장한다면 터져서 없어져버리고 남은 문자열들은 합쳐진다. 이때 다시 폭발문자열이 등장한다면 이것도 터져버린다는 것인데 폭발문자열이 C4라면
ACC44B -> AC4B -> AB가 된다는 의미이다.
- 이를 해결하기 위해서는 replace를 계속해서 돌려서는 안되고 stack으로 풀어야 시간안에 해결할 수 있다.