### PR TITLE
20200409 10:05 백준알고리즘/2002/추월

### DIFF
--- a/StudyExamples/src/baekjun/string/Overtake2002.java
+++ b/StudyExamples/src/baekjun/string/Overtake2002.java
@@ -1,0 +1,50 @@
+package baekjun.string;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+
+public class Overtake2002 {
+	static HashMap<String, Boolean> overtake = new HashMap<>();
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		int N = Integer.parseInt(br.readLine());
+		String[] input = new String[N];
+		String[] output = new String[N];
+		for(int i = 0; i<N; i++) {
+			String name = br.readLine();
+			overtake.put(name, false);
+			input[i] = name;
+		}
+		for(int i = 0; i<N; i++)
+			output[i] = br.readLine();
+		int cnt = 0;
+		int out_idx = 0;
+		for(int i = 0; i<N; i++) {
+			if(out_idx >= N) break;
+			String out = output[out_idx];
+			//input 배열의 차가 이미 추월한 차량으로 판정됐을 때, 혹은 input과 같은 순번으로 빠져나올때
+			if(overtake.get(input[i])) continue;
+			if(input[i].equals(out)) {
+				out_idx++;
+				continue;
+			}
+			else {
+				cnt++;
+				overtake.replace(out, true);
+				out_idx++;
+				i--;
+			}
+		}
+		bw.write(cnt + "");
+		bw.flush();
+		bw.close();
+		br.close();
+	}
+
+}


### PR DESCRIPTION
1) Category: 문자열 처리
2) 문제: https://www.acmicpc.net/problem/2002
3) 풀이내용:
- logic을 그대로 따라서 코딩을 했는데, 다른 풀이를 보았을때, hashmap에서 boolean 대신 integer로 터널에 진입하는 순서를 그대로 가지고 있다가 
- 출력 부분에서 순서가 뒤바뀌는 것을 찾아서 cnt를 세는 방법을 보았다. 그부분이 조금더 영리한 풀이인것 같다.