### PR TITLE
20200731 22:08 백준알고리즘 / 거울설치 2151

### DIFF
--- a/StudyExamples/src/baekjun/bfs/Mirror2151.java
+++ b/StudyExamples/src/baekjun/bfs/Mirror2151.java
@@ -5,11 +5,43 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.util.PriorityQueue;
 
 public class Mirror2151 {
 	static int N;
+	//ºÏ µ¿ ³² ¼­
+	static int dy[] = {-1, 0, 1, 0};
+	static int dx[] = {0, 1, 0, -1};
+	static int refraction[][] = {{1, 3}, {0, 2}, {1, 3}, {0, 2}};
+	static boolean visit[][][] = new boolean[51][51][4];
 	static char map[][] = new char[51][51];
 	static Point door[] = new Point[2];
+	
+	static int bfs() {
+		PriorityQueue<Point> pq = new PriorityQueue<Point>();
+		for(int dir = 0; dir<4; dir++)
+			pq.add(new Point(door[0].y, door[0].x, dir, 0));
+		
+		while(!pq.isEmpty()) {
+			Point now = pq.poll();
+			visit[now.y][now.x][now.dir] = true;
+			
+			if(now.y == door[1].y && now.x == door[1].x) {
+				return now.cnt;
+			}
+			int ny = now.y + dy[now.dir];
+			int nx = now.x + dx[now.dir];
+			if(ny < 0 || nx < 0 || ny >= N || nx >= N || visit[ny][nx][now.dir] || map[ny][nx] == '*') continue;
+			if(map[ny][nx] == '!') {
+				pq.add(new Point(ny, nx, refraction[now.dir][0], now.cnt + 1));
+				pq.add(new Point(ny, nx, refraction[now.dir][1], now.cnt + 1));
+			}
+			pq.add(new Point(ny, nx, now.dir, now.cnt));
+			
+		}
+		
+		return 0;
+	}
 	
 	public static void main(String[] args) throws IOException {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -19,20 +51,33 @@ public class Mirror2151 {
 			map[i] = br.readLine().toCharArray();
 			for(int j = 0; j<N; j++) {
 				if(map[i][j] == '#' && door[0] == null) 
-					door[0] = new Point(i, j);
+					door[0] = new Point(i, j, 0, 0);
 				else if(map[i][j] == '#' && door[0] != null)
-					door[1] = new Point(i, j);
-				
+					door[1] = new Point(i, j, 0, 0);
 			}
 		}
+		bw.write(String.valueOf(bfs()));
+		bw.flush();
+		bw.close();
+		br.close();
 	}
 	
-	static class Point {
+	static class Point implements Comparable<Point> {
 		int y;
 		int x;
-		public Point(int y, int x) { 
+		int dir;
+		int cnt;
+		
+		public Point(int y, int x, int dir, int cnt) { 
 			this.y = y;
 			this.x = x;
+			this.dir = dir;
+			this.cnt = cnt;
+		}
+
+		@Override
+		public int compareTo(Point p) {
+			return this.cnt - p.cnt;
 		}
 	}
 }

--- a/StudyExamples/src/baekjun/bfs/Mirror2151.java
+++ b/StudyExamples/src/baekjun/bfs/Mirror2151.java
@@ -1,0 +1,38 @@
+package baekjun.bfs;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Mirror2151 {
+	static int N;
+	static char map[][] = new char[51][51];
+	static Point door[] = new Point[2];
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		N = Integer.parseInt(br.readLine());
+		for(int i = 0; i<N; i++) {
+			map[i] = br.readLine().toCharArray();
+			for(int j = 0; j<N; j++) {
+				if(map[i][j] == '#' && door[0] == null) 
+					door[0] = new Point(i, j);
+				else if(map[i][j] == '#' && door[0] != null)
+					door[1] = new Point(i, j);
+				
+			}
+		}
+	}
+	
+	static class Point {
+		int y;
+		int x;
+		public Point(int y, int x) { 
+			this.y = y;
+			this.x = x;
+		}
+	}
+}


### PR DESCRIPTION
1) Category: BFS
2) 문제: https://www.acmicpc.net/problem/2151
3) 풀이내용: 
- 뭐가 됐든 , BFS 탐색을 돌아야 한다. 하지만 조건에 따라 거울 설치를 최소로 하여야 하기 때문에 BFS 순회과정에서 count 가 작은 것을 앞으로 당기게끔 PriorityQueue를 사용한다.
- 동,서 방향으로 들어오면 북,남으로 / 북,남으로 들어오면 동,서로 방향을 전환해주고 설치하지 않는 경우를 고려해 진행방향으로 계속 보내는 것을 PQ에 추가해준다면 도착 문에 먼저 도착하는 놈이 정답이다.